### PR TITLE
Herd type changed to Entity for success merge

### DIFF
--- a/namespaces/FLOCK/_0x408D1149C5E39C1E.json
+++ b/namespaces/FLOCK/_0x408D1149C5E39C1E.json
@@ -4,7 +4,7 @@
         "comment": "Remove the ped from a herd.",
         "params": [
             {
-                "type": "Herd",
+                "type": "Entity",
                 "name": "herd"
             },
             {

--- a/namespaces/FLOCK/_0x67A43EA3F6FE0076.json
+++ b/namespaces/FLOCK/_0x67A43EA3F6FE0076.json
@@ -4,7 +4,7 @@
         "comment": "Clear the herd.",
         "params": [
             {
-                "type": "Herd",
+                "type": "Entity",
                 "name": "herd"
             }
         ],

--- a/namespaces/FLOCK/_0x9E13ACC38BA8F9C3.json
+++ b/namespaces/FLOCK/_0x9E13ACC38BA8F9C3.json
@@ -4,7 +4,7 @@
         "comment": "Return whether the ped is in the herd.",
         "params": [
             {
-                "type": "Herd",
+                "type": "Entity",
                 "name": "herd"
             },
             {

--- a/namespaces/FLOCK/_0xE0961AED72642B80.json
+++ b/namespaces/FLOCK/_0xE0961AED72642B80.json
@@ -4,7 +4,7 @@
         "comment": "Delete and invalidate the herd.",
         "params": [
             {
-                "type": "Herd",
+                "type": "Entity",
                 "name": "herd"
             }
         ],


### PR DESCRIPTION
### Description
- definition of _0x67A43EA3F6FE0076 as _CLEAR_HERD(Herd herd)
- definition of _0xE0961AED72642B80 as _DELETE_HERD(Herd herd)
- definition of _0x9E13ACC38BA8F9C3 as _IS_PED_IN_HERD(Herd herd, Ped ped)
- definition of _0x408D1149C5E39C1E as _REMOVE_HERD_PED(Herd herd, Ped ped)

### Examples

```lua
local Herd = CreateHerd()

print(Citizen.InvokeNative(0x9E13ACC38BA8F9C3, animalPed)) -- _IS_PED_IN_HERD Print false
AddPedToFlock(Herd, animalPed)
print(Citizen.InvokeNative(0x9E13ACC38BA8F9C3, animalPed)) -- _IS_PED_IN_HERD Print true
Citizen.InvokeNative(0x408D1149C5E39C1E, Herd, animalPed) -- _REMOVE_HERD_PED
print(Citizen.InvokeNative(0x9E13ACC38BA8F9C3, animalPed)) -- _IS_PED_IN_HERD Print false

Citizen.InvokeNative(0x67A43EA3F6FE0076, Herd) -- _CLEAR_HERD
Citizen.InvokeNative(0xE0961AED72642B80, Herd) -- _DELETE_HERD
print(IsHerdValid(Herd)) -- Print false
```

### Source 

- script_rel/act_caunc_rustling.ysc.c (l5855 ; l5856 ; l5913 ; l5915)

### Notes

- The R* scripts that use herds are the standalone ones